### PR TITLE
Fix MessageLevel.h error when compiling on Debian Stable

### DIFF
--- a/launcher/MessageLevel.h
+++ b/launcher/MessageLevel.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <qlogging.h>
 #include <QString>
-#include <QtLogging>
 
 /**
  * @brief the MessageLevel Enum


### PR DESCRIPTION
I believe this is the correct header for older Qt 6 versions - there's no QLogging or anything
This could be an `#if` but I don't think that's particularly necessary